### PR TITLE
Add support for TYPE_MATCHES relocation

### DIFF
--- a/src/relocator.rs
+++ b/src/relocator.rs
@@ -426,6 +426,7 @@ impl<'a, 'b> Relocator<'a, 'b> {
             BtfCoreRelocKind::LocalTypeId
             | BtfCoreRelocKind::TargetTypeId
             | BtfCoreRelocKind::TypeExists
+            | BtfCoreRelocKind::TypeMatches
             | BtfCoreRelocKind::TypeSize => true,
             _ => false,
         }

--- a/src/types.rs
+++ b/src/types.rs
@@ -181,6 +181,7 @@ pub const BTF_TYPE_EXISTS: u32 = 8;
 pub const BTF_TYPE_SIZE: u32 = 9;
 pub const BTF_ENUMVAL_EXISTS: u32 = 10;
 pub const BTF_ENUMVAL_VALUE: u32 = 11;
+pub const BTF_TYPE_MATCHES: u32 = 12;
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone, DerivePread, Pwrite, IOread, IOwrite, SizeWith)]
@@ -855,6 +856,7 @@ pub enum BtfCoreRelocKind {
     TypeSize = 9,
     EnumvalExists = 10,
     EnumvalValue = 11,
+    TypeMatches = 12,
 }
 
 impl fmt::Display for BtfCoreRelocKind {
@@ -869,6 +871,7 @@ impl fmt::Display for BtfCoreRelocKind {
             BtfCoreRelocKind::LocalTypeId => write!(f, "local_type_id"),
             BtfCoreRelocKind::TargetTypeId => write!(f, "target_type_id"),
             BtfCoreRelocKind::TypeExists => write!(f, "type_exists"),
+            BtfCoreRelocKind::TypeMatches => write!(f, "type_matches"),
             BtfCoreRelocKind::TypeSize => write!(f, "type_size"),
             BtfCoreRelocKind::EnumvalExists => write!(f, "enumval_exists"),
             BtfCoreRelocKind::EnumvalValue => write!(f, "enumval_value"),
@@ -1492,6 +1495,7 @@ impl<'a> Btf<'a> {
                     BTF_TYPE_LOCAL_ID => BtfCoreRelocKind::LocalTypeId,
                     BTF_TYPE_TARGET_ID => BtfCoreRelocKind::TargetTypeId,
                     BTF_TYPE_EXISTS => BtfCoreRelocKind::TypeExists,
+                    BTF_TYPE_MATCHES => BtfCoreRelocKind::TypeMatches,
                     BTF_TYPE_SIZE => BtfCoreRelocKind::TypeSize,
                     BTF_ENUMVAL_EXISTS => BtfCoreRelocKind::EnumvalExists,
                     BTF_ENUMVAL_VALUE => BtfCoreRelocKind::EnumvalValue,


### PR DESCRIPTION
This change adds support for the TYPE_MATCHES relocation to the program.
This relocation backs the type match relation, which is introduced here:
https://lore.kernel.org/bpf/20220620231713.2143355-1-deso@posteo.net/

Signed-off-by: Daniel Müller <deso@posteo.net>