### PR TITLE
types: cast to arch-specific c_char instead of i8

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 use std::cmp::{max, min};
-use std::ffi::CStr;
+use std::ffi::{c_char, CStr};
 use std::fmt;
 use std::mem::size_of;
 
@@ -1535,7 +1535,7 @@ impl<'a> Btf<'a> {
     }
 
     fn get_btf_str(strs: &[u8], off: u32) -> BtfResult<&str> {
-        let c_str = unsafe { CStr::from_ptr(&strs[off as usize] as *const u8 as *const i8) };
+        let c_str = unsafe { CStr::from_ptr(&strs[off as usize] as *const u8 as *const c_char) };
         Ok(c_str.to_str()?)
     }
 }


### PR DESCRIPTION
Seems like CStr::from_ptr is expecting a pointer to c_char, not i8 (as you could get from documentation at [0]). So cast to c_char to solve the problem.

  [0] https://doc.rust-lang.org/std/ffi/struct.CStr.html#impl-CStr

Fixes: https://github.com/anakryiko/btfdump/issues/3