### PR TITLE
btfdump: Allow to dump from /sys/kernel/btf/vmlinux

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -4,7 +4,7 @@ use std::fmt;
 use std::mem::size_of;
 
 use object::{Object, ObjectSection};
-use scroll::Pread;
+use scroll::{Endian, Pread};
 use scroll_derive::{IOread, IOwrite, Pread as DerivePread, Pwrite, SizeWith};
 
 use crate::{btf_error, BtfError, BtfResult};
@@ -1084,15 +1084,12 @@ impl<'a> Btf<'a> {
         }
     }
 
-    pub fn load(elf: &object::File<'a>) -> BtfResult<Btf<'a>> {
-        let endian = if elf.is_little_endian() {
-            scroll::LE
-        } else {
-            scroll::BE
-        };
-        let mut btf = Btf::<'a> {
-            endian: endian,
-            ptr_sz: if elf.is_64() { 8 } else { 4 },
+    /// Helper method which keeps the common BTF loading logic and returns
+    /// both `Btf` and a subslice with the string section.
+    fn load(endian: Endian, ptr_sz: u32, data: &'a [u8]) -> BtfResult<(Self, &'a [u8])> {
+        let mut btf = Self {
+            endian,
+            ptr_sz,
             types: vec![BtfType::Void],
             has_ext: false,
             func_secs: Vec::new(),
@@ -1100,13 +1097,6 @@ impl<'a> Btf<'a> {
             core_reloc_secs: Vec::new(),
         };
 
-        let btf_section = elf
-            .section_by_name(BTF_ELF_SEC)
-            .ok_or_else(|| Box::new(BtfError::new("No .BTF section found!")))?;
-        let data = match btf_section.data() {
-            Ok(d) => d,
-            _ => panic!("expected borrowed data"),
-        };
         let hdr = data.pread_with::<btf_header>(0, endian)?;
         if hdr.magic != BTF_MAGIC {
             return btf_error(format!("Invalid BTF magic: {}", hdr.magic));
@@ -1130,12 +1120,29 @@ impl<'a> Btf<'a> {
             btf.types.push(t);
         }
 
+        Ok((btf, str_data))
+    }
+
+    /// Loads BTF information from the given ELF object file.
+    pub fn load_elf(elf: &object::File<'a>) -> BtfResult<Self> {
+        let endian = if elf.is_little_endian() {
+            scroll::LE
+        } else {
+            scroll::BE
+        };
+
+        let ptr_sz = if elf.is_64() { 8 } else { 4 };
+
+        let btf_section = elf
+            .section_by_name(BTF_ELF_SEC)
+            .ok_or_else(|| Box::new(BtfError::new("No .BTF section found!")))?;
+        let data = btf_section.data().expect("expected borrowed data");
+
+        let (mut btf, str_data) = Self::load(endian, ptr_sz, data)?;
+
         if let Some(ext_section) = elf.section_by_name(BTF_EXT_ELF_SEC) {
             btf.has_ext = true;
-            let ext_data = match ext_section.data() {
-                Ok(d) => d,
-                _ => panic!("expected borrowed data"),
-            };
+            let ext_data = ext_section.data().expect("expected borrowed data");
             let ext_hdr = ext_data.pread_with::<btf_ext_header_v1>(0, endian)?;
             if ext_hdr.magic != BTF_MAGIC {
                 return btf_error(format!("Invalid .BTF.ext magic: {}", ext_hdr.magic));
@@ -1171,6 +1178,34 @@ impl<'a> Btf<'a> {
         }
 
         Ok(btf)
+    }
+
+    /// Loads BTF information from the given slice of bytes.
+    pub fn load_file(data: &'a [u8]) -> BtfResult<Self> {
+        if data.starts_with(&BTF_MAGIC.to_ne_bytes()) {
+            // If the file starts with BTF magic number, parse BTF from the
+            // full file content.
+
+            #[cfg(target_endian = "little")]
+            let endian = scroll::LE;
+            #[cfg(target_endian = "big")]
+            let endian = scroll::BE;
+
+            #[cfg(target_pointer_width = "64")]
+            let ptr_sz = 8_u32;
+            #[cfg(target_pointer_width = "32")]
+            let ptr_sz = 4_u32;
+
+            let (btf, _) = Self::load(endian, ptr_sz, data)?;
+
+            Ok(btf)
+        } else {
+            // Otherwise, assume it's an object file and parse BTF from
+            // the `.BTF` section.
+
+            let file = object::File::parse(data)?;
+            Self::load_elf(&file)
+        }
     }
 
     pub fn type_size(t: &BtfType) -> usize {


### PR DESCRIPTION
Support dumping BTF not only from ELF files, but also from raw BTF information (which starts directly with BTF magic number) like the one peresent in /sys/kernel/btf/vmlinux.

This way, btfdump can be used for generating the vmlinux.h for the given kernel.

Also, don't use mmap, since it doesn't work on sysfs.