### PR TITLE
Replace lazy-static with standard library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ memmap = "0.7.0"
 scroll = "0.12.0"
 scroll_derive = "0.12.0"
 regex = "1"
-lazy_static = "1"
 bitflags = "2"
 
 [dev-dependencies]

--- a/src/c_dumper.rs
+++ b/src/c_dumper.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
+use std::sync::LazyLock;
 
-use lazy_static::lazy_static;
 use regex::RegexSet;
 
 use crate::types::*;
@@ -806,10 +806,8 @@ impl<'a> CDumper<'a> {
     }
 }
 
-lazy_static! {
-    static ref NAMES_BLACKLIST: RegexSet =
-        RegexSet::new(&["__builtin_va_list"]).expect("invalid blacklist regexes");
-}
+static NAMES_BLACKLIST: LazyLock<RegexSet> =
+    LazyLock::new(|| RegexSet::new(["__builtin_va_list"]).expect("invalid blacklist regexes"));
 
 const EMPTY: &str = "";
 const SPACE: &str = " ";


### PR DESCRIPTION
The lazy-static crate's functionality is available in the standard
library since Rust 1.80.0.

Link: https://github.com/rust-lang-nursery/lazy-static.rs?tab=readme-ov-file#standard-library
