### PR TITLE
Remove `--allow clippy::unused_unit`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,5 +28,4 @@ jobs:
 
       - run: cargo build  --profile ${{ matrix.profile }} --all-targets
       - run: cargo test   --profile ${{ matrix.profile }} --all-targets
-      # TODO(https://github.com/m4b/scroll/pull/112): Remove --allow clippy::unused_unit when merged.
-      - run: cargo clippy --profile ${{ matrix.profile }} --all-targets -- --deny warnings --allow clippy::unused_unit
+      - run: cargo clippy --profile ${{ matrix.profile }} --all-targets -- --deny warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ goblin = "0.9.2"
 object = "0.36.0"
 memmap2 = "0.9.0"
 scroll = "0.12.0"
-scroll_derive = "0.12.0"
+scroll_derive = "0.12.1"
 regex = "1"
 bitflags = "2"
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1018,7 +1018,7 @@ impl<'a> Btf<'a> {
     pub fn get_size_of(&self, type_id: u32) -> u32 {
         match self.type_by_id(type_id) {
             BtfType::Void => 0,
-            BtfType::Int(t) => (t.bits + 7) / 8,
+            BtfType::Int(t) => t.bits.div_ceil(8),
             BtfType::Volatile(t) => self.get_size_of(t.type_id),
             BtfType::Const(t) => self.get_size_of(t.type_id),
             BtfType::Restrict(t) => self.get_size_of(t.type_id),
@@ -1043,7 +1043,7 @@ impl<'a> Btf<'a> {
     pub fn get_align_of(&self, type_id: u32) -> u32 {
         match self.type_by_id(type_id) {
             BtfType::Void => 0,
-            BtfType::Int(t) => min(self.ptr_sz, (t.bits + 7) / 8),
+            BtfType::Int(t) => min(self.ptr_sz, t.bits.div_ceil(8)),
             BtfType::Volatile(t) => self.get_align_of(t.type_id),
             BtfType::Const(t) => self.get_align_of(t.type_id),
             BtfType::Restrict(t) => self.get_align_of(t.type_id),


### PR DESCRIPTION
scroll_derive 0.12.1 contains https://github.com/m4b/scroll/pull/112.
